### PR TITLE
feat: implement IntoIter for owned body

### DIFF
--- a/src/body.rs
+++ b/src/body.rs
@@ -188,3 +188,11 @@ impl<'a> IntoIterator for &'a Body<'a> {
         self.elems.iter()
     }
 }
+
+impl<'a> IntoIterator for Body<'a> {
+    type Item = (Key, Value<'a>);
+    type IntoIter = std::vec::IntoIter<(Key, Value<'a>)>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.elems.into_iter()
+    }
+}


### PR DESCRIPTION
IntoIter was only implemented for `&Body` and not for `Body`

Need this change for https://github.com/vectordotdev/vrl/pull/1010/files#r1746322167