### PR TITLE
feat: remove values that are not generated by the parser

### DIFF
--- a/src/body.rs
+++ b/src/body.rs
@@ -104,20 +104,13 @@ impl Body<'_> {
             Value::Str(s, q) => Value::Str(self.add_slice(s), q),
             Value::Owned(s) => Value::Str(self.add_slice(s.as_slice()), Quote::None),
             Value::List(vs) => Value::List(vs.into_iter().map(|v| self.add_value(v)).collect()),
-            Value::StringifiedList(vs) => {
-                Value::StringifiedList(vs.into_iter().map(|v| self.add_value(v)).collect())
-            }
-            Value::Segments(vs) => {
-                let vs = vs.iter().map(|s| self.add_slice(s)).collect();
-                Value::Segments(vs)
-            }
             Value::Map(vs) => Value::Map(
                 vs.into_iter()
                     .map(|(k, v)| (k, self.add_value(v)))
                     .collect(),
             ),
             // safety: These enum variants are self-contained.
-            Value::Empty | Value::Literal(_) | Value::Number(_) | Value::Skipped(_) => unsafe {
+            Value::Empty | Value::Number(_) => unsafe {
                 std::mem::transmute::<Value<'i>, Value<'a>>(v)
             },
         }


### PR DESCRIPTION
at https://github.com/vectordotdev/vrl/blob/5dd835138e94fc45316834ac8391558de6f0b8fe/src/stdlib/parse_auditd.rs#L97 we found that the variants that are not generated by the parser does not make sense for us, so we included a wildcard branch to catch those cases as a workaround. I assume that those variants are useful for [Laurel](https://github.com/threathunters-io/laurel), but as the parser was split off from Laurel, maybe it makes sense to also split those values and move the removed logic of this PR to laurel and convert from this parser `Value` to a extended `Value` in Laurel's internals. This way we don't have to take into account `Value` variants that are not generated by the parser.

What do you think of this change? It would help us a lot and this way we can "make illegal states unrepresentable"